### PR TITLE
make services panel 1x1 pixels during startup flash

### DIFF
--- a/GUI/Windows/MainWindow.xaml.cs
+++ b/GUI/Windows/MainWindow.xaml.cs
@@ -1798,20 +1798,24 @@ namespace Stoffi.Player.GUI.Windows
 
 				Dispatcher.Invoke(DispatcherPriority.Background, new Action(delegate()
 				{
+					var orgWidth = ControlPanel.Services.Width;
+					var orgHeight = ControlPanel.Services.Height;
+
+					// flash services panel in main window (this forces the browser to load)
+					ControlPanel.Services.Width = 1;
+					ControlPanel.Services.Height = 1;
 					ControlPanel.Container.Children.Remove(ControlPanel.Services);
 					ControlPanel.Services.Visibility = Visibility.Visible;
 					if (!ContentContainer.Children.Contains(ControlPanel.Services))
 						ContentContainer.Children.Add(ControlPanel.Services);
-				}));
 
-				//Thread.Sleep(50);
-
-				Dispatcher.Invoke(DispatcherPriority.Background, new Action(delegate()
-				{
+					// restore services panel into its original place
 					ContentContainer.Children.Remove(ControlPanel.Services);
 					ControlPanel.Services.Visibility = Visibility.Collapsed;
 					if (!ControlPanel.Container.Children.Contains(ControlPanel.Services))
 						ControlPanel.Container.Children.Add(ControlPanel.Services);
+					ControlPanel.Services.Width = orgWidth;
+					ControlPanel.Services.Height = orgHeight;
 				}));
 
 				ControlPanel.General.RestartClick += new RoutedEventHandler(UpgradeButton_Click);
@@ -2551,8 +2555,8 @@ namespace Stoffi.Player.GUI.Windows
 			taskbarPlay.Click += TaskbarPlayPause_Click;
 			taskbarNext = new ThumbnailToolBarButton(Properties.Resources.Next, U.T("TaskbarNext"));
 			taskbarNext.Click += TaskbarNext_Click;
-			TaskbarManager.Instance.ThumbnailToolBars.AddButtons(
-				new WindowInteropHelper(this).Handle, taskbarPrev, taskbarPlay, taskbarNext);
+			//TaskbarManager.Instance.ThumbnailToolBars.AddButtons(
+			//    new WindowInteropHelper(this).Handle, taskbarPrev, taskbarPlay, taskbarNext);
 
 			#endregion
 


### PR DESCRIPTION
When the services panel is briefly moved into the main window at
startup, so that the browser is loaded, make it 1x1 pixels so the user
doesn't see it.

This closes #3.